### PR TITLE
Add script to pull translations from poeditor

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,0 +1,3 @@
+POEDITOR_APITOKEN="Take the readonly token from https://poeditor.com/account/api"
+POEDITOR_PROJECT="146255"
+POEDITOR_LANGUAGES="bg en mk sq"

--- a/update-i18n.sh
+++ b/update-i18n.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+source .env
+
+function update() {
+  language=$1
+
+  url=$(curl -s -X POST https://api.poeditor.com/v2/projects/export \
+    -d api_token="${POEDITOR_APITOKEN}" \
+    -d id="${POEDITOR_PROJECT}" \
+    -d language="${language}" \
+    -d type="key_value_json" \
+    -d filters="translated" | jq -rc '.result.url')
+
+  echo "${language}=${url}"
+  content=$(curl -s $url)
+
+  if [ "$content" != "" ]; then
+    echo "$content" > i18n/${language}.json
+  else
+    echo "{}" > i18n/${language}.json
+  fi
+}
+
+for lang in $POEDITOR_LANGUAGES; do
+  update $lang
+done


### PR DESCRIPTION
Added an `example.env` that needs to be copied as `.env` and filled with user's api token retrieved from https://poeditor.com/account/api